### PR TITLE
Add option to only disable Hardware Acceleration for encoding only

### DIFF
--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bufio"
 	"fmt"
-	g "github.com/AllenDang/giu"
-	"github.com/jaypipes/ghw"
 	"io"
 	"strings"
+
+	g "github.com/AllenDang/giu"
+	"github.com/jaypipes/ghw"
 )
 
 func handleUpscalingLogs(stderr io.ReadCloser) string {
@@ -73,7 +74,7 @@ func buildUpscalingParams(anime Anime, resolution Resolution, shadersMode Shader
 		"-vf", fmt.Sprintf("format=yuv420p,hwupload,libplacebo=w=%d:h=%d:upscaler=ewa_lanczos:custom_shader_path=%s,hwdownload,format=yuv420p", resolution.Width, resolution.Height, shadersMode.Path),
 	)
 
-	if cvValue != "" && !disableHardwareAcceleration {
+	if cvValue != "" && !disableHardwareAcceleration && !disableHardwareAccelerationEncoding {
 		params = append(params, "-c:v", cvValue)
 	}
 
@@ -149,5 +150,8 @@ func searchHardwareAcceleration() {
 		// Something weird happened
 		cvValue = ""
 		logMessage("There's no available GPU acceleration, application may not work correctly! Please verify your GPU drivers or report bug on GitHub", false)
+	}
+	if disableHardwareAccelerationEncoding {
+		logMessage("You have disabled GPU encoding, so we're running with H.264 on your CPU", false)
 	}
 }

--- a/gui.go
+++ b/gui.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	g "github.com/AllenDang/giu"
-	"github.com/AllenDang/imgui-go"
-	"gopkg.in/vansante/go-ffprobe.v2"
 	"os"
 	"strings"
 	"time"
+
+	g "github.com/AllenDang/giu"
+	"github.com/AllenDang/imgui-go"
+	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
 func loop() {
@@ -57,6 +58,9 @@ func loop() {
 
 					g.Checkbox("Disable hardware acceleration", &disableHardwareAcceleration),
 					g.Tooltip("Should be used only for bad performance or compatibility issues"),
+
+					g.Checkbox("Disable hardware accelerated encoding (NVENC / OpenCL)", &disableHardwareAccelerationEncoding),
+					g.Tooltip("Can be used to encode with H.264"),
 
 					g.Checkbox("Debug mode", &debug),
 					g.Tooltip("Show more detailed logs, useful for troubleshooting and debugging"),

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	g "github.com/AllenDang/giu"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+
+	g "github.com/AllenDang/giu"
 )
 
 const version = "1.0.4"
@@ -44,12 +45,13 @@ var (
 	outputFormats = []string{"MP4", "AVI", "MKV"}
 
 	// Pointers for UI
-	selectedResolution          int32 = 5
-	selectedShadersMode         int32
-	selectedCompressionPreset   int32 = 2
-	selectedOutputFormat        int32
-	disableHardwareAcceleration bool
-	debug                       bool
+	selectedResolution                  int32 = 5
+	selectedShadersMode                 int32
+	selectedCompressionPreset           int32 = 2
+	selectedOutputFormat                int32
+	disableHardwareAcceleration         bool
+	disableHardwareAccelerationEncoding bool
+	debug                               bool
 
 	// UI variables
 	currentSpeed  = "Speed:"


### PR DESCRIPTION
Hello

I have added an option to disable Hardware Acceleration only for encoding, as a friend of mine had an issue with the hw encoder's quality. 