### PR TITLE
feat: add parallel processing with multi-nvdec unit support

### DIFF
--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -70,8 +70,17 @@ func handleUpscalingLogs(stderr io.ReadCloser, anime Anime, index int) string {
 
 		fileProgress[index] = currentProgress
 
+		// Newer version of FFMPEG add "elapsed=x" at the end of output line
+		// We need to handle both formats for best compatibility
+		var speedParameter string
+		if strings.Contains(line, "elapsed=") { // Newer FFMPEG releases
+			speedParameter = readOutputParameter(line, "speed", "elapsed")
+		} else { // Older ones
+			speedParameter = readOutputParameter(line, "speed", "")
+		}
+
 		// Speed
-		speedRaw := strings.ReplaceAll(readOutputParameter(line, "speed", ""), "x", "")
+		speedRaw := strings.ReplaceAll(speedParameter, "x", "")
 		if strings.Contains(speedRaw, ".") {
 			speedValue, _ := strconv.ParseFloat(speedRaw, 64)
 			if speedValue > 0 {

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -12,7 +12,7 @@ import (
 	g "github.com/AllenDang/giu"
 )
 
-func handleUpscalingLogs(stderr io.ReadCloser, anime Anime) string {
+func handleUpscalingLogs(stderr io.ReadCloser, anime Anime, index int) string {
 	scanner := bufio.NewScanner(stderr)
 	scanner.Split(bufio.ScanRunes)
 
@@ -30,59 +30,71 @@ func handleUpscalingLogs(stderr io.ReadCloser, anime Anime) string {
 		if !strings.HasPrefix(line, "frame=") {
 			trim := strings.ReplaceAll(line, "\r", "")
 			trim = strings.ReplaceAll(trim, "\n", "")
+
+			guiMutex.Lock()
 			logDebug(trim, false)
+			guiMutex.Unlock()
+
 			ffmpegLogs += line
 			line = ""
 			continue
 		}
 
+		guiMutex.Lock()
+
 		// It's line with speed and time
 		time := strings.Split(readOutputParameter(line, "time", "bitrate"), ".")[0]
 		millis := durationToMillis(time)
-		gui.Progress = float32(millis) / float32(anime.Length)
+
+		var currentProgress float32 = 0.0
+		if anime.Length > 0 {
+			currentProgress = float32(millis) / float32(anime.Length)
+		}
 
 		// FFMPEG may not report time, we must calculate it manually
 		if time == "N/A" && len(strings.Split(line, "frame=")) > 1 {
 			frame, _ := strconv.ParseFloat(readOutputParameter(line, "frame", "fps"), 32)
-			gui.Progress = float32(frame) / float32(anime.TotalFrames)
+			if anime.TotalFrames > 0 {
+				currentProgress = float32(frame) / float32(anime.TotalFrames)
+			}
 
 			fps, _ := strconv.ParseFloat(readOutputParameter(line, "fps", "q"), 32)
-			gui.CurrentSpeed = fmt.Sprintf("Speed: %.2fx", fps/anime.FrameRate)
-
-			leftFrames := anime.TotalFrames - int(frame)
-			leftMillis := int64((float32(leftFrames) / float32(fps)) * 1000)
-			gui.Eta = fmt.Sprintf("ETA: %s", formatMillis(leftMillis))
+			if anime.FrameRate > 0 {
+				fileSpeed[index] = fps / anime.FrameRate
+			}
 		}
+
+		fileProgress[index] = currentProgress
 
 		// Speed
 		speedRaw := strings.ReplaceAll(readOutputParameter(line, "speed", ""), "x", "")
 		if strings.Contains(speedRaw, ".") {
-			gui.CurrentSpeed = fmt.Sprintf("Speed: %s", speedRaw)
-			speedValue, _ := strconv.ParseFloat(speedRaw, 32)
-
-			// Just for safety
-			if speedValue != 0 {
-				etaMillis := float64(anime.Length-millis) / speedValue
-				gui.Eta = fmt.Sprintf("ETA: %s", formatMillis(int64(etaMillis)))
+			speedValue, _ := strconv.ParseFloat(speedRaw, 64)
+			if speedValue > 0 {
+				fileSpeed[index] = speedValue
 			}
 		}
 
-		// Progress bar
-		rounded := int(gui.Progress * 100)
-		if rounded == 99 {
-			gui.Progress = 1
-			gui.ProgressLabel = "100%"
-		} else {
-			gui.ProgressLabel = fmt.Sprintf("%d%%", rounded)
+		// Calculate ETA using the latest speed (from either FPS or Speed tag)
+		if fileSpeed[index] > 0 && anime.Length > 0 {
+			remainingMillis := anime.Length - millis
+			if remainingMillis > 0 {
+				etaMillis := int64(float64(remainingMillis) / fileSpeed[index])
+				fileEta[index] = formatMillis(etaMillis)
+			}
 		}
+
+		// We don't calculate global ETA/Progress here anymore, purely per-file.
+		// Layout update is handled by main loop or g.Update() calls.
 
 		ffmpegLogs = strings.ReplaceAll(ffmpegLogs, progressLine, line)
 		gui.Logs = strings.ReplaceAll(gui.Logs, progressLine, line)
 		progressLine = line
 
-		line = ""
 		g.Update()
+		guiMutex.Unlock()
 
+		line = ""
 	}
 
 	return ffmpegLogs

--- a/ffmpeg.go
+++ b/ffmpeg.go
@@ -56,6 +56,10 @@ func handleUpscalingLogs(stderr io.ReadCloser, anime Anime, index int) string {
 			frame, _ := strconv.ParseFloat(readOutputParameter(line, "frame", "fps"), 32)
 			if anime.TotalFrames > 0 {
 				currentProgress = float32(frame) / float32(anime.TotalFrames)
+				// If time is N/A, estimate current millis from progress
+				if anime.Length > 0 {
+					millis = int64(currentProgress * float32(anime.Length))
+				}
 			}
 
 			fps, _ := strconv.ParseFloat(readOutputParameter(line, "fps", "q"), 32)

--- a/hardware.go
+++ b/hardware.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/jaypipes/ghw"
 	"strings"
+
+	"github.com/jaypipes/ghw"
 )
 
 func searchHardwareAcceleration() {
@@ -73,6 +74,17 @@ func searchHardwareAcceleration() {
 		if encoder.Vendor != "cpu" {
 			settings.Encoder = int32(index)
 			break
+		}
+	}
+
+	// Smart Default for Parallel Processing
+	if settings.MaxConcurrentUpscales == 0 {
+		if gpuAv1Supported { // RTX 40 or 50 series
+			settings.MaxConcurrentUpscales = 2
+			logDebug("Smart Default: Detected High-End GPU, setting concurrency to 2", false)
+		} else {
+			settings.MaxConcurrentUpscales = 1
+			logDebug("Smart Default: Standard GPU, setting concurrency to 1", false)
 		}
 	}
 }

--- a/resources/build/build.bat
+++ b/resources/build/build.bat
@@ -1,27 +1,34 @@
 @echo off
-cd ..
-cd ..
+
+cd /d "%~dp0\..\.."
 
 echo Cleaning up...
 IF EXIST Anime4K-GUI.syso (
-    del Anime4K-GUI.syso
-)
-
-IF EXIST build (
-    rmdir /s /Q build
+  del Anime4K-GUI.syso
 )
 
 echo Generating RC data...
 windres resources\build\app.rc -O coff -o Anime4K-GUI.syso
 
-mkdir build
+IF EXIST build (
+  IF NOT "%1"=="--keep" (
+    rmdir /s /Q build
+  )
+)
+IF NOT EXIST build (
+  mkdir build
+)
 
 echo Building project...
 go build -ldflags "-s -w -H=windowsgui -extldflags=-static" -o build\Anime4K-GUI.exe
 
 echo Copying runtime resources...
-xcopy resources\shaders build\shaders\ /E > NUL
-xcopy resources\ffmpeg build\ffmpeg\ /E > NUL
+IF NOT EXIST build\shaders (
+  xcopy resources\shaders build\shaders\ /E > NUL
+)
+IF NOT EXIST build\ffmpeg (
+  xcopy resources\ffmpeg build\ffmpeg\ /E > NUL
+)
 
 del Anime4K-GUI.syso
 

--- a/settings.go
+++ b/settings.go
@@ -6,18 +6,19 @@ import (
 )
 
 type Settings struct {
-	UseSavedPosition bool   `json:"use_saved_position"`
-	PositionX        int    `json:"position_x"`
-	PositionY        int    `json:"position_y"`
-	Resolution       int32  `json:"resolution"`
-	Shaders          int32  `json:"shaders"`
-	Encoder          int32  `json:"encoder"`
-	Crf              int32  `json:"crf"`
-	Cq               int32  `json:"cq"`
-	OutputFormat     int32  `json:"output_format"`
-	CpuThreads       int32  `json:"cpu_threads"`
-	DebugMode        bool   `json:"debug_mode"`
-	Version          string `json:"version"`
+	UseSavedPosition      bool   `json:"use_saved_position"`
+	PositionX             int    `json:"position_x"`
+	PositionY             int    `json:"position_y"`
+	Resolution            int32  `json:"resolution"`
+	Shaders               int32  `json:"shaders"`
+	Encoder               int32  `json:"encoder"`
+	Crf                   int32  `json:"crf"`
+	Cq                    int32  `json:"cq"`
+	OutputFormat          int32  `json:"output_format"`
+	CpuThreads            int32  `json:"cpu_threads"`
+	DebugMode             bool   `json:"debug_mode"`
+	Version               string `json:"version"`
+	MaxConcurrentUpscales int32  `json:"max_concurrent_upscales"`
 }
 
 func saveSettings() {


### PR DESCRIPTION
# feat: add parallel processing with multi-nvdec unit support

Fixes #49

## Description

This PR introduces parallel processing capabilities, allowing users with powerful GPUs (especially those with multiple NVDEC/NVENC units like RTX 4090/5090) to run multiple upscaling jobs simultaneously. It also includes several bug fixes and UI improvements

## Key Changes

### 🚀 Parallel Processing
- **Concurrent Upscaling**: Added support for running multiple FFmpeg instances in parallel.
- **UI Control**: Added a "Concurrent Upscales" dropdown in Settings (Options: 1, 2, 3, 4).
    - Includes logic to force Concurrency = 1 when a CPU encoder is selected to prevent system overload.

### 📊 UI Improvements
- **New Columns**: Added **ETA** and **Progress** columns to the file list table.
- **Visual Progress**: Status column now displays a visual progress bar for active files.
- **Window Size**: Increased default window width to **1800px** and widened the Logs panel to accommodate the extra columns without cramping.
- **Typos/Labels**: Renamed "Status/Progress" to just "Progress".

### 🐛 Bug Fixes
- **"Stuck on Waiting"**: Fixed a bug where cancelling a batch would permanently leave the app in a "Cancelled" state, requiring a restart to process new files.
- **UI Freeze on Cancel**: Moved the `taskkill` command to a background goroutine to prevent the GUI from freezing while stopping FFmpeg processes.
- **Terminal Popup**: Added `HideWindow` attribute to the `taskkill` command to suppress the annoying terminal window flash.

### 🛠️ Build Script
- **Robust Pathing**: Updated `build.bat` to work correctly regardless of the current working directory (e.g., when run via double-click or from a different shell location).
- **Keep Flag**: Added support for a `--keep` flag to preserve the `build` directory (useful for retaining `settings.json` between builds).

## Verification
- Tested with 1, 2, and 3 concurrent jobs on NVIDIA RTX 5080 GPU.
- Verified CPU fallback enforces 1 job.
- Verified Cancellation is instant and does not freeze UI.
- Verified Build script works from root and subdirectories.
