### PR TITLE
Pin Vulkan device to discrete GPU on hybrid-GPU systems Fixes #66

### DIFF
--- a/src/Hardware/GpuDetector.cpp
+++ b/src/Hardware/GpuDetector.cpp
@@ -36,8 +36,13 @@ namespace Upscaler {
         bool apple = false;
         bool nvidiaAv1Supported = false;
         bool amdAv1Supported = false;
+        // Original-cased names, kept separately from the lowercased detection strings below,
+        // so we can later tell FFmpeg's Vulkan device selector exactly which discrete GPU to use.
+        std::string nvidiaGpuName;
+        std::string amdGpuName;
         for (int i = 0; i < gpus.size(); i++) {
             std::string& gpu = gpus[i];
+            std::string originalCaseName = gpu;
             Instance->GetLogger().Info("  {}. {} {}", i + 1, gpu, (i == gpus.size() - 1 ? "\n" : ""));
             std::ranges::transform(gpu, gpu.begin(),
                                    [](const unsigned char c) { return std::tolower(c); });
@@ -51,12 +56,14 @@ namespace Upscaler {
 
             if (gpu.find("amd") != std::string::npos) {
                 amd = true;
+                amdGpuName = originalCaseName;
                 // Only RX 7000 and RX 9000 support AV1 encoding
                 amdAv1Supported = gpu.find("rx 7") != std::string::npos || gpu.find("rx 9") != std::string::npos;
             }
 
             if (gpu.find("nvidia") != std::string::npos) {
                 nvidia = true;
+                nvidiaGpuName = originalCaseName;
                 // Only RTX 4000 and RTX 5000 support AV1 encoding
                 nvidiaAv1Supported = gpu.find("rtx 40") != std::string::npos || gpu.find("rtx 50") != std::string::npos;
             }
@@ -93,6 +100,22 @@ namespace Upscaler {
 
         if (intel) {
             Instance->GetLogger().Warn("Found Intel dGPU which is not supported. Only CPU based encoders will be available");
+        }
+
+        // Vulkan-based shader upscaling (libplacebo) is initialized without pinning a
+        // specific GPU (see VideoProcessor::BuildFFmpegCommand), so on hybrid-GPU laptops
+        // the Vulkan loader may otherwise pick a weak integrated GPU first. Remember which
+        // discrete GPU we settled on above so that command can explicitly request it.
+        if (nvidia) {
+            m_PreferredVulkanDeviceName = nvidiaGpuName;
+        } else if (amd) {
+            m_PreferredVulkanDeviceName = amdGpuName;
+        } else {
+            m_PreferredVulkanDeviceName.clear();
+        }
+
+        if (!m_PreferredVulkanDeviceName.empty()) {
+            Instance->GetLogger().Debug("Preferred Vulkan device for shader upscaling: {}", m_PreferredVulkanDeviceName);
         }
 
 #ifdef __linux__

--- a/src/Hardware/GpuDetector.h
+++ b/src/Hardware/GpuDetector.h
@@ -15,6 +15,13 @@ namespace Upscaler {
         std::string GetVendorFromDeviceID(const std::string&);
         void AnalyzeAvailableEncoders();
 
+        // Name of the discrete GPU (Nvidia/AMD) that should be used for Vulkan-based
+        // shader upscaling, so it isn't left to the Vulkan loader's default enumeration
+        // order (which may pick an integrated GPU on hybrid-GPU/Optimus laptops).
+        // Empty if no discrete GPU was found, in which case Vulkan device selection
+        // falls back to the default behavior.
+        const std::string& GetPreferredVulkanDeviceName() const { return m_PreferredVulkanDeviceName; }
+
 #ifdef _WIN32
         std::wstring GetDevicePropertyString(HDEVINFO hDevInfo, SP_DEVINFO_DATA& devInfoData, DWORD property);
 #endif
@@ -22,6 +29,9 @@ namespace Upscaler {
         GpuDetector(App* instance)
             : Instance(instance) {
         }
+
+    private:
+        std::string m_PreferredVulkanDeviceName;
     };
 }
 

--- a/src/Video/VideoProcessor.cpp
+++ b/src/Video/VideoProcessor.cpp
@@ -131,7 +131,18 @@ namespace Upscaler {
 
         // Use Vulkan only on Windows and Linux
 #ifndef __APPLE__
-        command += "-init_hw_device vulkan ";
+        // On hybrid-GPU laptops (e.g. Intel iGPU + NVIDIA/AMD dGPU), Vulkan's default
+        // device enumeration order is not guaranteed to prefer the discrete GPU, which
+        // can silently push the whole shader pass onto a much weaker integrated GPU
+        // while only NVENC/AMF encoding correctly uses the discrete one.
+        // If GpuDetector found a discrete GPU, pin Vulkan to it by name so this can't happen.
+        const std::string& preferredGpu = Instance->GetGpuDetector().GetPreferredVulkanDeviceName();
+        if (!preferredGpu.empty()) {
+            command += std::format("-init_hw_device \"vulkan=vk:{}\" ", preferredGpu);
+        }
+        else {
+            command += "-init_hw_device vulkan ";
+        }
 #endif
 
 


### PR DESCRIPTION
# Pin Vulkan device to the discrete GPU on hybrid-GPU (Optimus) systems

Fixes #66

## Problem

On laptops with both an integrated GPU (e.g. Intel UHD) and a discrete GPU
(NVIDIA/AMD), the Anime4K shader/upscale step could silently run on the
integrated GPU instead of the discrete one, because `BuildFFmpegCommand()`
calls `-init_hw_device vulkan` with no device specified. This leaves device
selection entirely up to the Vulkan loader's default enumeration order,
which is not guaranteed to prefer the discrete GPU.

`GpuDetector::AnalyzeAvailableEncoders()` already correctly determines which
vendor is the "real" discrete GPU (its "Found Intel iGPU, ignoring it" log
line), but that result was previously only used to pick available *encoders*
(NVENC/AMF), not to influence the Vulkan device used for the shader filter
itself. On affected hardware this could mean 0.05x-ish upscaling speed
because the iGPU handled the actual per-frame shader work while only the
final NVENC encode used the discrete GPU.

## Fix

- `GpuDetector` now also remembers the original-cased device name of the
  discrete GPU (NVIDIA preferred, then AMD) it detected, exposed via
  `GetPreferredVulkanDeviceName()`. Empty if no discrete GPU was found (e.g.
  CPU-only or Apple systems), preserving the previous default behavior.
- `VideoProcessor::BuildFFmpegCommand()` now passes that name to FFmpeg's
  Vulkan device selector (`-init_hw_device "vulkan=vk:<name>"`), which
  FFmpeg matches against the enumerated Vulkan device name. If no discrete
  GPU was detected, it falls back to the previous unpinned
  `-init_hw_device vulkan` behavior exactly as before.

## Testing

Tested on a Windows 11 laptop with Intel UHD Graphics + NVIDIA GeForce
RTX 5060 Laptop GPU, using the same source video and shader (Anime4K Mode A,
2560x1440 target, H.265 NVENC) for a clean before/after comparison.

**Before the fix**, Task Manager showed the shader stage running on the
integrated GPU: Intel GPU pegged near 99-100%, Nvidia GPU 3D engine at 0%
(only Video Encode showed minor activity). Reported speed: ~0.05x, ETA
~8 hours for a 23-minute episode.

Before fix - Task Manager
<img width="2396" height="1360" alt="1-before-fix-taskmanager-0 05x" src="https://github.com/user-attachments/assets/9ab6d4ee-6e78-4992-baad-f0db8546a416" />

**After applying this fix and rebuilding from source** (no environment
variables or manual workarounds set), Task Manager showed the shader stage
correctly running on the discrete GPU: Nvidia GPU at ~89% usage, 57°C.
Reported speed: 2.97x, ETA ~7 minutes for the same video.

After fix - Task Manager
<img width="432" height="664" alt="2a-after-fix-taskmanager-89percent" src="https://github.com/user-attachments/assets/c7877a09-e04f-4d68-859f-3c113b5a0203" />

After fix - App window showing 2.97x speed
<img width="2394" height="659" alt="2b-after-fix-speed-2 97x" src="https://github.com/user-attachments/assets/4d8bea6e-529a-4c5d-a97a-260cf5c607f8" />

Also independently verified via Task Manager's Details tab (per-process GPU
Engine column) that `ffmpeg.exe` is specifically listed against the Nvidia
GPU's 3D engine during processing, confirming the actual video-processing
process — not just background UI rendering — is on the discrete GPU.

I don't have access to an AMD discrete + Intel iGPU laptop to test that
branch, but the logic mirrors the already-existing AMD detection path, so
it should behave the same way.